### PR TITLE
feat: change `string` to `interface` for values

### DIFF
--- a/handler/get.go
+++ b/handler/get.go
@@ -32,8 +32,8 @@ func (h *Handler) GetHandler(w http.ResponseWriter, r *http.Request) {
 
 // GetResponse represents the response for the GET request.
 type GetResponse struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
 }
 
 // ErrorResponse represents the error response.

--- a/internal/data/database.go
+++ b/internal/data/database.go
@@ -6,13 +6,13 @@ import (
 
 // Database Struct
 type Database struct {
-	data  map[string]string
+	data  map[string]interface{}
 	mutex sync.RWMutex
 }
 
 // creates a new instance of the Database.
 func NewDatabase() *Database {
 	return &Database{
-		data: make(map[string]string),
+		data: make(map[string]interface{}),
 	}
 }

--- a/internal/data/get.go
+++ b/internal/data/get.go
@@ -1,6 +1,6 @@
 package data
 
-func Get(db *Database, key string) (string, bool) {
+func Get(db *Database, key string) (interface{}, bool) {
 	db.mutex.RLock()
 	defer db.mutex.RUnlock()
 


### PR DESCRIPTION
Since Redis not only saves string types as its value, I decided to change the string to `interface{}` for more scalability.